### PR TITLE
feat: update github workflow

### DIFF
--- a/.github/workflows/publish-script.yml
+++ b/.github/workflows/publish-script.yml
@@ -1,20 +1,68 @@
-name: Publish PSubShell.ps1
-run-name: ${{ github.actor }} is publishing PSubShell.ps1 🚀
-on: [push]
+name: Publish PSubShell Script
+run-name: ${{ github.actor }} is publishing PSubShell 🚀
+on:
+  workflow_dispatch:    # Allows for manual triggering
+  push:
+    branches:
+      - main            # Run the worfklow on push events to main
+  pull_request:
+    branches:
+      - '*'             # Run the workflow for all pull requests
+  release:
+    types:
+      - published       # Run the workflow when a release is published
+
+defaults:
+  run:
+    shell: pwsh
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  BuildDirectory: ${{ github.workspace }}/.build
+
 jobs:
   build:
     name: Run build.ps1 build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Run the build script to create the versioned script file
       - name: Build
         run: |
           ./build.ps1 build
         shell: pwsh
-      - name: Publish
+
+      # Publish the script as an artifact, so it can be used in other jobs
+      - uses: actions/upload-artifact@v3
+        with:
+          name: PSubShell
+          if-no-files-found: error
+          retention-days: 7
+          path: ./build/PSubShell.ps1
+
+  deploy:
+    # Publish only when creating a GitHub Release
+    # https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - uses: actions/checkout@v4
+
+      # Download the script created in the previous job
+      - uses: actions/download-artifact@v3
+        with:
+          name: PSubShell
+          path: ${{ env.BuildDirectory }}
+
+      # Publish script to PowerShell Gallery
+      # Use --skip-duplicate to prevent errors if a package with the same version already exists.
+      # If you retry a failed workflow, already published packages will be skipped without error.
+      - name: Publish script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           ./build.ps1 publish
-        shell: pwsh

--- a/.github/workflows/publish-script.yml
+++ b/.github/workflows/publish-script.yml
@@ -40,7 +40,7 @@ jobs:
           name: PSubShell
           if-no-files-found: error
           retention-days: 7
-          path: ./build/PSubShell.ps1
+          path: ${{ env.BuildDirectory }}/PSubShell.ps1
 
   deploy:
     # Publish only when creating a GitHub Release

--- a/PSubShell.ps1
+++ b/PSubShell.ps1
@@ -2,7 +2,7 @@
 
 <#PSScriptInfo
 
-.VERSION 0.2.0
+.VERSION 0.3.0
 
 .GUID dbd31207-825d-4cdc-8e52-7c575e0ca5d9
 


### PR DESCRIPTION
Slowly moving towards a more disciplined GitHub workflow. The changes here will only publish PSubShell.ps1 on a release, rather than on every build.